### PR TITLE
Bugfix-o-rama

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,6 +16,7 @@
             "module": "dumpty.main",
             "console": "integratedTerminal",
             "args": [
+                "--verbose",
                 "--config",
                 "test.yaml",
                 "--credentials",

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -10,7 +10,7 @@ spark:
     spark.default.parallelism: "8"
     spark.eventLog.enabled: "false"
     spark.eventLog.dir: "spark_log"
-    spark.driver.extraClassPath: "sqljdbc42.jar:gcs-connector-hadoop3-latest.jar:spark-3.1-bigquery-0.28.0-preview.jar"
+    spark.driver.extraClassPath: "sqljdbc42.jar:gcs-connector-hadoop3-2.2.11-shaded.jar:spark-3.1-bigquery-0.28.0-preview.jar"
     spark.sql.session.timeZone: "America/Los_Angeles"
     spark.sql.jsonGenerator.ignoreNullFields": "false"
     spark.sql.debug.maxToStringFields: "25"
@@ -40,20 +40,23 @@ jdbc:
     password: "PASSWORD"
     driver: "com.microsoft.sqlserver.jdbc.SQLServerDriver"
     fetchsize: "1000"
+
 schema: dbo
-# Python thread pool -- used for introspection and launching spark Jobs
-job_threads: 32 
+
 # Your target file size for Spark output files
 target_partition_size_bytes: 52428800
+
+tinydb_database_file: tinydb.json
+
 # Introspection expires after this many seconds since last
 introspection_expire_s: 604800
-tinydb_database_file: tinydb.json
 
 # Controls parallelism of SQL introspection workers (one SQL connection per worker)
 # note: introspect_workers + spark.threads = total parallel SQL queries
 introspect_workers: 8
+
 # No more than this number of Spark jobs will be in 'running' state.
-extract_workers: 4
+extract_workers: 8
+
 # Controls parallelism of BigQuery load operations 
 load_workers: 8
-

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -46,6 +46,9 @@ schema: dbo
 # Your target file size for Spark output files
 target_partition_size_bytes: 52428800
 
+# First-pass introspection will use this value to determine partition size
+default_rows_per_partition: 1000000
+
 tinydb_database_file: tinydb.json
 
 # Introspection expires after this many seconds since last

--- a/src/dumpty/config.py
+++ b/src/dumpty/config.py
@@ -46,7 +46,7 @@ class Config(YAMLWizard):
     tinydb_database_file: str = "tinydb.json"
     reconcile: bool = False
     normalize_schema: bool = True
-    partitioning_threshold: int = 1e6
+    default_rows_per_partition: int = 1e6
     introspect_workers: int = 8
     extract_workers: int = 8
     load_workers: int = 32

--- a/src/dumpty/exceptions.py
+++ b/src/dumpty/exceptions.py
@@ -7,7 +7,10 @@ class ValidationException(Exception):
 
 
 class ExtractException(Exception):
-    def __init__(self, extract):
+    def __init__(self, extract, message: str = None):
         self.extract = extract
-        self.message = f"Exception extracting {extract.name}"
+        if message is None:
+            self.message = f"Exception extracting {extract.name}"
+        else:
+            self.message = message
         super().__init__(self.message)

--- a/src/dumpty/gcp.py
+++ b/src/dumpty/gcp.py
@@ -15,117 +15,118 @@ from google.cloud.bigquery.retry import DEFAULT_RETRY
 from dumpty import logger
 
 
-def get_size_bytes(uri: str) -> int:
+class GCP:
+    """GCP helper functions using a shared client instance
     """
-    Returns size (bytes) of all objects matching a GCS prefix or glob pattern
-    """
-    parse = urlparse(uri)
-    client: StorageClient = StorageClient()
-    bucket = parse.netloc
-    path = parse.path
-    if "*" in path:
-        prefix = os.path.dirname(path).lstrip("/") + "/"
-        glob = os.path.basename(path)
-    else:
-        prefix = path.lstrip("/")
-        glob = None
-    blobs = client.list_blobs(bucket, prefix=prefix)
-    blob: Blob
-    bytes = 0
-    for blob in blobs:
-        if glob and "*" in glob:
-            if PurePath(blob.name).match(glob):
+
+    def __init__(self):
+        """Initialize a :class:`.GCP` instance. 
+        """
+        self._storage_client = StorageClient()
+        self._bigquery_client = BigqueryClient()
+
+    def get_size_bytes(self, uri: str) -> int:
+        """
+        Returns size (bytes) of all objects matching a GCS prefix or glob pattern
+        """
+        parse = urlparse(uri)
+        bucket = parse.netloc
+        path = parse.path
+        if "*" in path:
+            prefix = os.path.dirname(path).lstrip("/") + "/"
+            glob = os.path.basename(path)
+        else:
+            prefix = path.lstrip("/")
+            glob = None
+        blobs = self._storage_client.list_blobs(bucket, prefix=prefix)
+        blob: Blob
+        bytes = 0
+        for blob in blobs:
+            if glob and "*" in glob:
+                if PurePath(blob.name).match(glob):
+                    bytes += blob.size
+            else:
                 bytes += blob.size
+        return bytes
+
+    def upload_from_string(self, data: str, uri: str, content_type="application/json"):
+        """
+        Writes a string to a URI eg. gs://bucket/name (defaults to application/json content type)
+        """
+        matches = re.match("gs://(.*?)/(.*)", uri)
+        if matches:
+            bucket, name = matches.groups()
         else:
-            bytes += blob.size
-    return bytes
+            raise Exception(f"Invalid GCS URI {uri}")
+        bucket: Bucket = self._storage_client.bucket(bucket)
+        blob: Blob = bucket.blob(name)
+        blob.upload_from_string(data=data, content_type=content_type)
 
-
-def upload_from_string(data: str, uri: str, content_type="application/json"):
-    """
-    Writes a string to a URI eg. gs://bucket/name (defaults to application/json content type)
-    """
-    matches = re.match("gs://(.*?)/(.*)", uri)
-    if matches:
-        bucket, name = matches.groups()
-    else:
-        raise Exception(f"Invalid GCS URI {uri}")
-    client: StorageClient = StorageClient()
-    bucket: Bucket = client.bucket(bucket)
-    blob: Blob = bucket.blob(name)
-    blob.upload_from_string(data=data, content_type=content_type)
-
-
-def bigquery_create_dataset(dataset_ref: str, description: str = None, location: str = "US", labels: dict = {}, drop: bool = False) -> Dataset:
-    """
-    Creates a Dataset in BigQuery
-    """
-    logger.info(f"Using dataset {dataset_ref}")
-    client = BigqueryClient()
-    exists = False
-    ref = DatasetReference.from_string(dataset_ref)
-    try:
-        dataset_ref: Dataset = client.get_dataset(ref)
-        if drop:
-            logger.info(f"Dropping dataset {dataset_ref.dataset_id}")
-            client.delete_dataset(
-                dataset_ref, not_found_ok=True, delete_contents=True)
+    def bigquery_create_dataset(self, dataset_ref: str, description: str = None, location: str = "US", labels: dict = {}, drop: bool = False) -> Dataset:
+        """
+        Creates a Dataset in BigQuery
+        """
+        logger.info(f"Using dataset {dataset_ref}")
+        exists = False
+        ref = DatasetReference.from_string(dataset_ref)
+        try:
+            dataset_ref: Dataset = self._bigquery_client.get_dataset(ref)
+            if drop:
+                logger.info(f"Dropping dataset {dataset_ref.dataset_id}")
+                self._bigquery_client.delete_dataset(
+                    dataset_ref, not_found_ok=True, delete_contents=True)
+            else:
+                exists = True
+        except NotFound:
+            dataset_ref: Dataset = Dataset(ref)
+        dataset_ref.description = description
+        dataset_ref.location = location
+        dataset_ref.labels = labels
+        if exists:
+            logger.debug(
+                f"Dataset {dataset_ref.dataset_id} already exists, updating")
+            return self._bigquery_client.update_dataset(dataset_ref, fields=["description", "location", "labels"])
         else:
-            exists = True
-    except NotFound:
-        dataset_ref: Dataset = Dataset(ref)
-    dataset_ref.description = description
-    dataset_ref.location = location
-    dataset_ref.labels = labels
-    if exists:
-        logger.debug(
-            f"Dataset {dataset_ref.dataset_id} already exists, updating")
-        return client.update_dataset(dataset_ref, fields=["description", "location", "labels"])
-    else:
-        return client.create_dataset(dataset_ref)
+            return self._bigquery_client.create_dataset(dataset_ref)
 
+    def bigquery_create_table(self, table_ref: str, schema: List[dict], description: str = None, labels: dict = {}) -> Table:
+        """
+        Creates a Table in BigQuery
+        """
+        table_ref: Table = Table(TableReference.from_string(table_ref), schema)
+        table_ref.description = description
+        table_ref.labels = labels
+        logger.info(
+            f"Creating empty table {table_ref.dataset_id}.{table_ref.table_id}")
+        return self._bigquery_client.create_table(table_ref, exists_ok=True)
 
-def bigquery_create_table(table_ref: str, schema: List[dict], description: str = None, labels: dict = {}) -> Table:
-    """
-    Creates a Table in BigQuery
-    """
-    client = BigqueryClient()
-    table_ref: Table = Table(TableReference.from_string(table_ref), schema)
-    table_ref.description = description
-    table_ref.labels = labels
-    logger.info(
-        f"Creating empty table {table_ref.dataset_id}.{table_ref.table_id}")
-    return client.create_table(table_ref, exists_ok=True)
+    def bigquery_load(self, uri: str, table: str, format: str, schema: List[dict], description: str = None, location="US"):
+        """
+        Loads a dataset into BigQuery from GCS bucket
+        """
+        if format == "json":
+            source_format = SourceFormat.NEWLINE_DELIMITED_JSON
+        elif format == "csv":
+            source_format = SourceFormat.CSV
+        elif format == "parquet":
+            source_format = SourceFormat.PARQUET
+        elif format == "orc":
+            source_format = SourceFormat.ORC
+        else:
+            raise Exception("Unknown format {}".format(format))
 
+        job_config = LoadJobConfig(
+            schema=[SchemaField.from_api_repr(field)
+                    for field in schema],
+            source_format=source_format,
+            create_disposition=CreateDisposition.CREATE_IF_NEEDED,
+            write_disposition=WriteDisposition.WRITE_TRUNCATE,
+            destination_table_description=description
+        )
 
-def bigquery_load(uri: str, table: str, format: str, schema: List[dict], description: str = None, location="US"):
-    """
-    Loads a dataset into BigQuery from GCS bucket
-    """
-    if format == "json":
-        source_format = SourceFormat.NEWLINE_DELIMITED_JSON
-    elif format == "csv":
-        source_format = SourceFormat.CSV
-    elif format == "parquet":
-        source_format = SourceFormat.PARQUET
-    elif format == "orc":
-        source_format = SourceFormat.ORC
-    else:
-        raise Exception("Unknown format {}".format(format))
+        # Some tables may take longer to load than the default deadline of 600s
+        load_job = self._bigquery_client.load_table_from_uri(uri, table, retry=DEFAULT_RETRY.with_timeout(
+            1800), job_config=job_config, location=location)
+        load_job.result()
 
-    client = BigqueryClient()
-    job_config = LoadJobConfig(
-        schema=[SchemaField.from_api_repr(field)
-                for field in schema],
-        source_format=source_format,
-        create_disposition=CreateDisposition.CREATE_IF_NEEDED,
-        write_disposition=WriteDisposition.WRITE_TRUNCATE,
-        destination_table_description=description
-    )
-
-    # Some tables may take longer to load than the default deadline of 600s
-    load_job = client.load_table_from_uri(uri, table, retry=DEFAULT_RETRY.with_timeout(
-        1800), job_config=job_config, location=location)
-    load_job.result()
-
-    return load_job.output_rows, load_job.output_bytes
+        return load_job.output_rows, load_job.output_bytes

--- a/src/dumpty/main.py
+++ b/src/dumpty/main.py
@@ -115,7 +115,7 @@ def main(args=None):
 
     # Default retry for network operations: 2^x * 1 second between each retry, starting with 5s, up to 30s, die after 30 minutes of retries
     # reraise=True places the exception at the END of the stack-trace dump
-    retryer = Retrying(wait=wait_random_exponential(multiplier=1, min=5, max=30), after=after_log(logger, logging.ERROR),
+    retryer = Retrying(wait=wait_random_exponential(multiplier=1, min=5, max=30), after=after_log(logger, logging.WARNING),
                        stop=(stop_after_delay(1800) | stop_after_attempt(0 if not config.retry else 999)), reraise=True)
 
     # Create spark logdir if needed

--- a/src/dumpty/main.py
+++ b/src/dumpty/main.py
@@ -101,6 +101,9 @@ def config_from_args(argv) -> Config:
         parser.error(
             f"Loading a dataset requires gs:// URI (uri is {config.target_uri}")
 
+    if config.target_uri is not None and config.target_uri.endswith("/"):
+        parser.error(f"target_uri cannot end with /")
+
     if config.project is not None:
         os.environ['GOOGLE_CLOUD_PROJECT'] = config.project
     if config.credentials is not None:

--- a/src/dumpty/main.py
+++ b/src/dumpty/main.py
@@ -38,8 +38,11 @@ def config_from_args(argv) -> Config:
     parser.add_argument('--drop', action='store_true', default=None,
                         help='Drop the destination dataset before creating it')
 
-    parser.add_argument('--verbose', action='store_true', default=None,
-                        help='Enable verbose (debug) logging')
+    parser.add_argument('-d', '--debug', help="Debug logging (DEBUG)",
+                        action="store_const", dest="loglevel", const=logging.DEBUG, default=logging.WARNING)
+
+    parser.add_argument('-v', '--verbose', help="Verbose logging (INFO)",
+                        action="store_const", dest="loglevel", const=logging.INFO)
 
     parser.add_argument('--no-progress', action='store_true', dest='progress',
                         help='Do not show progress bar')
@@ -60,6 +63,7 @@ def config_from_args(argv) -> Config:
                         help='project.dataset to load extract (requires gs:// uri)')
 
     args = parser.parse_args(argv)
+    logger.setLevel(args.loglevel)
 
     # Parses YAML as a bare Jina2 template (no round-trip parsing)
     template: Template = Environment(loader=FileSystemLoader('.')).from_string(
@@ -89,10 +93,6 @@ def config_from_args(argv) -> Config:
         config.project = args.project
     if args.credentials is not None:
         config.credentials = args.credentials
-    if args.verbose is not None:
-        logger.setLevel(logging.INFO)
-    else:
-        logger.setLevel(logging.WARNING)
 
     if config.target_dataset is not None and "." not in config.target_dataset:
         parser.error("Dataset must be in format project.dataset")
@@ -190,10 +190,12 @@ def main(args=None):
 
     if config.target_dataset is not None:
         summary['consistent'] = all(x.consistent() for x in completed)
-        summary['bq_bytes'] = sum(x.bq_bytes for x in completed)
+        summary['bq_bytes'] = sum(
+            x.bq_bytes if x.bq_bytes is not None else 0 for x in completed)
 
     if config.target_uri is not None:
-        summary['gcs_bytes'] = sum(x.gcs_bytes for x in completed)
+        summary['gcs_bytes'] = sum(
+            x.gcs_bytes if x.gcs_bytes is not None else 0 for x in completed)
 
     with open(config.log_file, "w") as outfile:
         outfile.write(json.dumps(summary, indent=4, default=str))

--- a/src/dumpty/pipeline.py
+++ b/src/dumpty/pipeline.py
@@ -74,24 +74,6 @@ class QueueWorker(Thread):
 
     def shutdown(self):
         self._shutdown = True
-        while not self._shutdown:
-            try:
-                extract: Extract = self.step.in_queue.get(timeout=1)
-                try:
-                    self.busy = True
-                    self.step.out_queue.put(self.step.func(extract))
-                except Exception as ex:
-                    try:
-                        raise ExtractException(extract) from ex
-                    except ExtractException as ex:
-                        logger.error(ex)
-                        traceback.print_exc()
-                        self.step.error_queue.put(ex)
-                finally:
-                    self.busy = False
-                    self.step.in_queue.task_done()
-            except Empty:
-                pass
 
 
 class QueueWorkerPool():

--- a/src/dumpty/pipeline.py
+++ b/src/dumpty/pipeline.py
@@ -74,6 +74,27 @@ class QueueWorker(Thread):
 
     def shutdown(self):
         self._shutdown = True
+        while not self._shutdown:
+            try:
+                extract: Extract = self.step.in_queue.get(timeout=1)
+                try:
+                    self.busy = True
+                    self.step.out_queue.put(self.step.func(extract))
+                except Exception as ex:
+                    try:
+                        raise ExtractException(extract) from ex
+                    except ExtractException as ex:
+                        logger.error(ex)
+                        traceback.print_exc()
+                        self.step.error_queue.put(ex)
+                finally:
+                    self.busy = False
+                    self.step.in_queue.task_done()
+            except Empty:
+                pass
+
+    def shutdown(self):
+        self._shutdown = True
 
 
 class QueueWorkerPool():
@@ -85,6 +106,10 @@ class QueueWorkerPool():
 
     def busy_count(self):
         return sum(worker.busy for worker in self.workers)
+
+    def shutdown(self):
+        for worker in self.workers:
+            worker.shutdown()
 
     def shutdown(self):
         for worker in self.workers:
@@ -386,6 +411,11 @@ class Pipeline:
         return extract
 
     def _extract(self, extract: Extract, uri: str) -> str:
+
+        session = self._spark_session
+        if session.sparkContext._jsc is None:
+            raise ExtractException(
+                extract, f"Spark context lost trying to extract {extract.name}, is Spark shutting down?")
 
         session = self._spark_session
         if session.sparkContext._jsc is None:

--- a/src/dumpty/pipeline.py
+++ b/src/dumpty/pipeline.py
@@ -12,7 +12,7 @@ from typing import Callable, List
 from pyspark import SparkConf
 from pyspark.sql import DataFrame, SparkSession
 from pyspark.sql.functions import col
-from sqlalchemy import Column, MetaData, Table, func, inspect
+from sqlalchemy import Column, MetaData, Table, func, inspect, literal_column
 from sqlalchemy.engine import Engine, Inspector
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import sqltypes
@@ -287,9 +287,9 @@ class Pipeline:
         pk = table.primary_key.columns[0] if table.primary_key else None
         if self.engine.dialect.name == "mssql":
             # MSSQL COUNT(*) can overflow if > INT_MAX
-            count_fn = func.count_big(pk)
+            count_fn = func.count_big(literal_column("*"))
         else:
-            count_fn = func.count(pk)
+            count_fn = func.count(literal_column("*"))
         with Session(self.engine) as session:
             if pk is not None:
                 is_numeric = isinstance(pk.type, sqltypes.Numeric)

--- a/src/dumpty/util.py
+++ b/src/dumpty/util.py
@@ -1,6 +1,9 @@
 import random
 import re
 import datetime
+from sqlalchemy.sql.functions import GenericFunction
+from sqlalchemy.sql import sqltypes
+from sqlalchemy import literal_column
 
 
 def normalize_str(x: str) -> str:
@@ -26,3 +29,33 @@ def sql_string(value):
     if isinstance(value, (datetime.datetime)):
         return value.strftime("%Y-%m-%d %H:%M:%S")
     return value
+
+
+class count_big(GenericFunction):
+    r"""The MSSQL count_big aggregate function.  With no arguments,
+    emits COUNT \*.
+
+    E.g.::
+
+        from sqlalchemy import func
+        from sqlalchemy import select
+        from sqlalchemy import table, column
+
+        my_table = table('some_table', column('id'))
+
+        stmt = select(func.count_big()).select_from(my_table)
+
+    Executing ``stmt`` would emit::
+
+        SELECT count_big(*) AS count_1
+        FROM some_table
+
+
+    """
+    type = sqltypes.Integer
+    inherit_cache = True
+
+    def __init__(self, expression=None, **kwargs):
+        if expression is None:
+            expression = literal_column("*")
+        super(count_big, self).__init__(expression, **kwargs)

--- a/src/dumpty/util.py
+++ b/src/dumpty/util.py
@@ -1,5 +1,6 @@
 import random
 import re
+import datetime
 
 
 def normalize_str(x: str) -> str:
@@ -16,3 +17,12 @@ def filter_shuffle(seq):
         return result
     except:
         return seq
+
+
+def sql_string(value):
+    """Some Python types cast to String values that break SQL when cast to varchar.
+    For example datetime includes 6-digit microseconds which breaks MSSQL.
+    """
+    if isinstance(value, (datetime.datetime)):
+        return value.strftime("%Y-%m-%d %H:%M:%S")
+    return value


### PR DESCRIPTION
This has the GCP reuse bugfix, better exception handling, faster shutdown. PK introspection now catches PK's that are useless for partitioning (ITEM_AUDIT_HX PK contains a single value '120' for all 800M rows). Those tables will now be dumped single-threaded. 

Also a new flag '--debug' which is more talky than '--verbose'

input `partitioning_threshold` changed to `default_rows_per_partition` for clarity.

Note that 💩 tables like ITEM_AUDIT_HX are huge and can only be dumped single-threaded, so they should be put at the top of the table list so they dump ASAP. 
