### PR TITLE
REVIEWED: Deepa - Deploy the new incremental DUMPTY ETL for LPCH Clarity to production (PHASE 1)

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,3 +1,14 @@
-DUMPTY CHANGELOG
+= DUMPTY Changelog
+:uri-repo: https://github.com/stanfordmed/dumpty
+:uri-jira: https://stanfordmed.atlassian.net/browse
+:icons: font
+:star: icon:star[role=red]
+ifndef::icons[]
+:star: &#9733;
+endif::[]
 
+This document provides a high-level view of the changes introduced in DUMPTY by release.
+For a detailed view of what has changed, refer to the {uri-repo}/commits/main[commit history] on GitHub.
+
+== DUMPTY Release 2023-10-11
 * ({uri-jira}/STAR-7141[STAR-7141]) - Speed up table counting in dumpty with new optional flag

--- a/CHANGELOG_dbalraj_incremental_clarity.adoc
+++ b/CHANGELOG_dbalraj_incremental_clarity.adoc
@@ -1,0 +1,5 @@
+PHASE 1 of Incremental Clarity ETL for LPCH:
+* ({uri-jira}/STAR-6838[STAR-6838]) - Definition for Incremental Clarity ETL for LPCH Clarity + Build a PoC for couple of LPCH Clarity tables
+* ({uri-jira}/STAR-7442[STAR-7442]) - Change DUMPTY so that it will extract and load a LPCH Clarity table from on premise LPCH Clarity only if it has data changes
+* ({uri-jira}/STAR-7474[STAR-7474]) - QC for the updated DUMPTY for 27,600 LPCH Clarity tables so that it will extract and load only those tables that has data changes
+* ({uri-jira}/STAR-7550[STAR-7550]) - Deploy the new incremental DUMPTY ETL for LPCH Clarity to production

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -55,7 +55,7 @@ target_partition_size_bytes: 52428800
 # First-pass introspection will use this value to determine partition size
 default_rows_per_partition: 1000000
 
-tinydb_database_file: tinydb.json
+tinydb_database_file: tinydb_dumpy.json
 
 # Introspection expires after this many seconds since last
 introspection_expire_s: 604800
@@ -109,3 +109,5 @@ schema: dbo
 tables: 
   - REPORTS
   - LOGS
+tinydb_date: tinydb_date.json
+last_successful_run: "20-NOV-2023"

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -1,26 +1,32 @@
+{%- set THREADS = env['THREADS'] %}
+{%- set CREDENTIALS = env['CREDENTIALS'] %}
+{%- set INTROSPECT_THREADS = env['INTROSPECT_THREADS'] %}
+{%- set BQ_LOAD_THREADS = env['BQ_LOAD_THREADS'] -%}
+{%- set EXTRACT_LOG_FILE = env['EXTRACT_LOG_FILE'] -%}
 spark: 
-  threads: 8
+  threads: {{THREADS}}
   format: "json"
   compression: "gzip"
   normalize_schema: "true"
   timestamp_format: "yyyy-MM-dd HH:mm:ss"
+  log_level: INFO
   properties:
+    #spark.scheduler.mode: "fair"
     spark.ui.showConsoleProgress: "false"
-    spark.default.parallelism: "8"
+    spark.default.parallelism: "{{THREADS}}"
     spark.eventLog.enabled: "false"
     spark.eventLog.dir: "spark_log"
-    spark.driver.extraClassPath: "spark-hadoop-cloud_2.12-3.3.2.jar:mssql-jdbc-12.2.0.jre11.jar:gcs-connector-hadoop3-2.2.11-shaded.jar:spark-3.1-bigquery-0.28.0-preview.jar"
+    spark.task.maxFailures: "20"
+    spark.hadoop.fs.gs.http.max.retry: "20"
+    # 2023/05/24 - added cache size to hopefully fix "410 Gone" errors 
+    # https://github.com/GoogleCloudDataproc/hadoop-connectors/pull/264
+    spark.hadoop.fs.gs.outputstream.upload.cache.size: "67108864"
+    spark.driver.extraClassPath: "spark-hadoop-cloud_2.12-3.3.2.jar:mssql-jdbc-12.2.0.jre11.jar:gcs-connector-hadoop3-2.2.12-shaded.jar:spark-3.1-bigquery-0.28.0-preview.jar"
     spark.sql.session.timeZone: "America/Los_Angeles"
     spark.sql.jsonGenerator.ignoreNullFields": "false"
-    spark.sql.debug.maxToStringFields: "25"
-    #spark.dynamicAllocation.enabled: "true"
-    #spark.dynamicAllocation.minExecutors: "1"
-    #spark.dynamicAllocation.maxExecutors: "4"
     spark.hadoop.google.cloud.auth.service.account.enable: "true"
-    spark.hadoop.google.cloud.auth.service.account.json.keyfile: "key.json"
-    # NOTE: Below require Hadoop 3.3.5+ jars
-    # https://hadoop.apache.org/docs/r3.3.5/hadoop-mapreduce-client/hadoop-mapreduce-client-core/manifest_committer.html
-    # v1 committer is very slow, v2 is not safe for GCS. This one is supposed to be safe.
+    spark.hadoop.google.cloud.auth.service.account.json.keyfile: "{{CREDENTIALS}}"
+    # NOTE: Below require Hadoop 3.3.5+ jars installed
     spark.hadoop.mapreduce.outputcommitter.factory.scheme.gcs: "org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterFactory"
     spark.hadoop.mapreduce.outputcommitter.factory.scheme.gs: "org.apache.hadoop.mapreduce.lib.output.committer.manifest.ManifestCommitterFactory"
     spark.hadoop.mapreduce.manifest.committer.delete.target.files: "true"
@@ -28,86 +34,42 @@ spark:
     spark.sql.sources.commitProtocolClass: "org.apache.spark.internal.io.cloud.PathOutputCommitProtocol"
     spark.executor.memory: "8g"
     spark.driver.memory: "16g"
-    # Change to G1GC prevents GC slowdowns entirely
     spark.executor.defaultJavaOptions: "-XX:+UseG1GC"
     spark.driver.defaultJavaOptions: "-XX:+UseG1GC"
     spark.storage.memoryFraction: "0"
     spark.sql.debug.maxToStringFields: "500"
 sqlalchemy:
   url: "mssql+pyodbc://USERNAME:PASSWORD@DBHOSTNAME:PORT/DATABASE?driver=ODBC+Driver+18+for+SQL+Server&TrustServerCertificate=yes&Encrypt=yes"
-  pool_size: 20
-  max_overflow: 20
-  isolation_level: "READ UNCOMMITTED"
   connect_args:
     connect_timeout: 60
+  isolation_level: "READ UNCOMMITTED"
 jdbc:
-  url: "jdbc:sqlserver://HOSTNAME:PORT;databaseName=DATABASE;encrypt=true;trustServerCertificate=true;"
+  url: "jdbc:sqlserver://HOSTNAME:PORT;databaseName=DATABASE;sendStringParametersAsUnicode=false;encrypt=true;trustServerCertificate=true;"
   properties:
     user: USERNAME
     password: "PASSWORD"
     driver: "com.microsoft.sqlserver.jdbc.SQLServerDriver"
-    fetchsize: "1000"
+    fetchsize: "2000"
     sessionInitStatement: "SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED"
 
-# Your target file size for Spark output files
-target_partition_size_bytes: 52428800
+# 50 MiB is our target .json.gz size
+# Make sure this is less than spark.hadoop.fs.gs.outputstream.upload.cache.size above
+target_partition_size_bytes: 50000000 
 
 # First-pass introspection will use this value to determine partition size
 default_rows_per_partition: 1000000
+introspection_expire_s: 1209600 # 2 weeks
 
 tinydb_database_file: tinydb_dumpy.json
-
-# Introspection expires after this many seconds since last
-introspection_expire_s: 604800
+tinydb_date: tinydb_date.json
+last_successful_run: "1-DEC-2023"
 
 # Controls parallelism of SQL introspection workers (one SQL connection per worker)
 # note: introspect_workers + spark.threads = total parallel SQL queries
-introspect_workers: 8
-
+introspect_workers: {{INTROSPECT_THREADS}}
 # No more than this number of Spark jobs will be in 'running' state.
-extract_workers: 8
-
+extract_workers: 64
 # Controls parallelism of BigQuery load operations 
-load_workers: 8
+load_workers: {{BQ_LOAD_THREADS}}
 
-# GCS bucket URI for extrated tables
-target_uri: gs://bucket/path
-
-# project_id.dataset to create
-target_dataset: my_project_id.my_dataset_id
-
-# Access entries at dataset creation time. You will want to include the service account here!
-target_dataset_access_entries:
-  - role: "OWNER"
-    userByEmail: "etl@my_project.iam.gserviceaccount.com"
-  - role: "OWNER"
-    userByEmail: "dba@somewhere.com"
-
-# Additional access entries to grant when dataset has completed loading
-target_dataset_additional_access_entries:
-  - role: "READER"
-    userByEmail: "reader@somewhere.com"
-
-# Labels to apply at dataset creation time
-target_dataset_pre_labels:
-  loading: true
-
-# Labels to apply when dataset has completed loading
-target_dataset_post_labels:
-  loading: false
-
-# Delete the dataset before extracting
-drop_dataset: false
-
-# Retry GCP functions that fail
-retry: false
-
-# Source database schema name
-schema: dbo
-
-# Tables to extract from above schema
-tables: 
-  - REPORTS
-  - LOGS
-tinydb_date: tinydb_date.json
-last_successful_run: "20-NOV-2023"
+log_file: {{EXTRACT_LOG_FILE}}

--- a/src/dumpty/config.py
+++ b/src/dumpty/config.py
@@ -27,13 +27,18 @@ class JdbcConfig:
     properties: Dict
 
 
-@ dataclass
+@dataclass
 class Config(YAMLWizard):
     spark: SparkConfig
     jdbc: JdbcConfig
     sqlalchemy: SqlalchemyConfig
+
     schema: str
     tables: List[str]
+
+    credentials: str = None
+
+    project: str = None
     target_uri: str = None
     target_dataset: str = None
     target_dataset_description: str = None
@@ -46,21 +51,22 @@ class Config(YAMLWizard):
     target_dataset_additional_access_entries: List[dict] = field(
         default_factory=list)
     target_partition_size_bytes: int = 52428800
-    introspection_expire_s: int = 0  # 0 = no expiration
-    drop_dataset: bool = False
-    progress_bar: bool = True
-    log_file: str = 'extract.json'
-    project: str = None
-    credentials: str = None
-    retry: bool = False
-    tinydb_database_file: str = "tinydb_dumpy.json"
-    reconcile: bool = False
-    normalize_schema: bool = True
+
     default_rows_per_partition: int = 1e6
+    introspection_expire_s: int = 0  # 0 = no expiration
     introspect_workers: int = 8
     extract_workers: int = 8
     load_workers: int = 32
-    fastcount: bool = False
-    tinydb_date: str = "tinydb_date.json"
+    drop_dataset: bool = False
+    normalize_schema: bool = True
     last_successful_run: str = None
     extract: str = None
+    tables_query: str = None
+    tinydb_database_file: str = "tinydb_dumpy.json"
+    tinydb_date: str = "tinydb_date.json"
+    log_file: str = 'extract.json'
+
+    retry: bool = False
+    reconcile: bool = False
+    fastcount: bool = False
+    progress_bar: bool = True

--- a/src/dumpty/config.py
+++ b/src/dumpty/config.py
@@ -53,7 +53,7 @@ class Config(YAMLWizard):
     project: str = None
     credentials: str = None
     retry: bool = False
-    tinydb_database_file: str = "tinydb.json"
+    tinydb_database_file: str = "tinydb_dumpy.json"
     reconcile: bool = False
     normalize_schema: bool = True
     default_rows_per_partition: int = 1e6
@@ -61,3 +61,6 @@ class Config(YAMLWizard):
     extract_workers: int = 8
     load_workers: int = 32
     fastcount: bool = False
+    tinydb_date: str = "tinydb_date.json"
+    last_successful_run: str = None
+    extract: str = None

--- a/src/dumpty/main.py
+++ b/src/dumpty/main.py
@@ -27,7 +27,7 @@ from dumpty import logger
 
 def config_from_args(argv) -> Config:
     parser = argparse.ArgumentParser(
-        description="Clarity database export utility named DUMPTY")
+        description="MS SQL Server Database export utility named DUMPTY")
 
     parser.add_argument('--spark-loglevel', default='WARN', dest='spark_loglevel',
                         help='Set Spark logging level: ALL, DEBUG, ERROR, FATAL, INFO, OFF, TRACE, WARN(default)')
@@ -195,7 +195,7 @@ def main(args=None):
             with engine.connect() as con:
 
                 # Create destination dataset
-                # DO NOT DROP THE SINGLE COPY OF RAW CLARITY DATASET - drop_dataset: false
+                # DO NOT DROP THE SINGLE COPY OF DATASET - drop_dataset: false
                 if config.target_dataset is not None:
                     retryer(pipeline.gcp.bigquery_create_dataset, dataset_ref=config.target_dataset, drop=config.drop_dataset, location=config.target_dataset_location,
                             description=config.target_dataset_description, labels=config.target_dataset_pre_labels, access_entries=config.target_dataset_access_entries)
@@ -221,10 +221,6 @@ def main(args=None):
 
                     logger.info("Running INCREMENTAL EXTRACTION ETL...")
 
-                    #query = "SELECT DISTINCT TABLE_NAME FROM [CLARITY].[dbo].[CR_STAT_EXTRACT] WHERE CONVERT(DATE, INITIALIZE_TIME) >= CONVERT(DATE, '" + last_successful_run + \
-                    #    "') AND STATUS IN ('Success', 'Warning') AND LOAD_TYPE IN ('FULL', 'REQ', 'APPEND') AND EXEC_DESCRIPTOR LIKE 'rpt%prd~primary%' AND FILE_SIZE_BYTES > 0 " + \
-                    #    "UNION SELECT DISTINCT TABLE_NAME FROM [CLARITY].[dbo].[CR_STAT_DERTBL] WHERE CONVERT(DATE, END_DATE_ABSOLUTE) >= CONVERT(DATE, '" + last_successful_run + \
-                    #    "') AND STATUS IN ('Success', 'Warning') AND LOAD_TYPE IN ('FULL', 'REQ', 'APPEND') "
                     query = config.tables_query
                     rs = con.execute(query)
                     rs_all = rs.fetchall()

--- a/src/dumpty/main.py
+++ b/src/dumpty/main.py
@@ -79,7 +79,6 @@ def config_from_args(argv) -> Config:
         Path(args.config).read_text())
 
     template.environment.filters['shuffle'] = filter_shuffle
-    #???parsed = template.render(env=os.environ, last_successful_run=last_successful_run)
     parsed = template.render(env=os.environ)
     if args.parse:
         print(parsed)

--- a/src/dumpty/main.py
+++ b/src/dumpty/main.py
@@ -167,7 +167,7 @@ def main(args=None):
     # Default retry for network operations: 2^x * 1 second between each retry, starting with 5s, up to 30s, die after 30 minutes of retries
     # reraise=True places the exception at the END of the stack-trace dump
     retryer = Retrying(wait=wait_random_exponential(multiplier=1, min=5, max=30), after=after_log(logger, logging.WARNING),
-                       stop=(stop_after_delay(600) | stop_after_attempt(0 if not config.retry else 999)), reraise=True, 
+                       stop=(stop_after_delay(7200) | stop_after_attempt(0 if not config.retry else 999)), reraise=True, 
                        retry=retry_if_not_exception_type(BadRequest))
 
     # Create spark logdir if needed

--- a/src/dumpty/pipeline.py
+++ b/src/dumpty/pipeline.py
@@ -340,9 +340,10 @@ class Pipeline:
             else:
                 logger.debug(f"Getting count(*) of {extract.name}")
                 if self.config.fastcount:
-                    result = session.execute(f"EXEC sp_spaceused N'{self.config.schema}.{extract.name}';").fetchall()
+                    result = session.execute(
+                        f"EXEC sp_spaceused N'{self.config.schema}.{extract.name}';").fetchall()
                     logger.debug(
-                            f"fast counting result of {result[0][1].rstrip()}")
+                        f"fast counting result of {result[0][1].rstrip()}")
                     extract.rows = int(result[0][1].rstrip())
                 else:
                     qry = session.query(
@@ -488,7 +489,8 @@ class Pipeline:
 
         if extract.rows == 0:
             # save only the schema if table is empty
-            self._save_schema(extract, self.config.target_uri, self.gcp.upload_from_string)
+            self._save_schema(extract, self.config.target_uri,
+                              self.gcp.upload_from_string)
             return extract
 
         extract_uri = self._extract(extract, self.config.target_uri)
@@ -516,7 +518,8 @@ class Pipeline:
                     extract.partitions = recommendation
                     extract.introspect_date = None  # triggers new introspection next run
 
-        self._save_schema(extract, self.config.target_uri, self.gcp.upload_from_string)
+        self._save_schema(extract, self.config.target_uri,
+                          self.gcp.upload_from_string)
         return extract
 
     def _save_schema(self, extract: Extract, target_uri: str, upload_from_string: str):
@@ -527,7 +530,7 @@ class Pipeline:
                 f.write(json_schema)
         else:
             self.retryer(self.gcp.upload_from_string, json_schema,
-                            f"{target_uri}/{normalize_str(extract.name)}/schema.json")
+                         f"{target_uri}/{normalize_str(extract.name)}/schema.json")
 
     def load(self, extract: Extract) -> Extract:
         """Loads an Extract into BigQuery
@@ -569,9 +572,11 @@ class Pipeline:
             :raises: :class:`.ValidationException` when a table is not found. Use this
             to fail early if you are not sure if the tables are actually in the SQL database.
         """
-        logger.info(f"Reconciling list of tables against schema {self.config.schema}")
+        logger.info(
+            f"Reconciling list of tables against schema {self.config.schema}")
         sql_tables = self._inspector.get_table_names(schema=self.config.schema)
-        not_found = [t for t in table_names if t.lower() not in (table.lower() for table in sql_tables)]
+        not_found = [t for t in table_names if t.lower() not in (
+            table.lower() for table in sql_tables)]
         if len(not_found) > 0:
             raise ValidationException(
                 f"Could not find these tables in {self.config.schema}: {','.join(not_found)}")


### PR DESCRIPTION
PHASE 1 -->

* STAR-6838 - Definition for Incremental Clarity ETL for LPCH Clarity + Build a PoC for couple of LPCH Clarity tables
* STAR-7442 - Change DUMPTY so that it will extract and load a LPCH Clarity table from on premise LPCH Clarity only if it has data changes
* STAR-7474 - QC for the updated DUMPTY for 27,600 LPCH Clarity tables so that it will extract and load only those tables that has data changes
* STAR-7550 - Deploy the new incremental DUMPTY ETL for LPCH Clarity to production